### PR TITLE
Fix frontend Ingress service name

### DIFF
--- a/frontend/k8s/ingress.yaml
+++ b/frontend/k8s/ingress.yaml
@@ -17,8 +17,8 @@ spec:
         paths:
           - path: /
             pathType: Prefix
-            backend:
-              service:
-                name: frontend
-                port:
-                  number: 80
+              backend:
+                service:
+                  name: cloudmart-ui
+                  port:
+                    number: 80


### PR DESCRIPTION
## Summary
- update ingress to point to `cloudmart-ui` Service

## Testing
- `kubectl version --client` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855bf3c6d5c8324bb20829b61f1b407